### PR TITLE
Fixed M_PI definition not getting pulled in on Win32

### DIFF
--- a/Graph.cpp
+++ b/Graph.cpp
@@ -33,6 +33,11 @@
 	@brief Implementation of Graph
  */
 
+#ifdef _WIN32
+#define _USE_MATH_DEFINES
+#include <cmath>
+#endif
+
 #include "Graph.h"
 #include <cairomm/context.h>
 


### PR DESCRIPTION
On Win32, a specific macro has to be defined before including `<cmath>` in order to be able to use `M_PI`.